### PR TITLE
Add ability to force swap-io of operations

### DIFF
--- a/lib/b_asic/core_operations.py
+++ b/lib/b_asic/core_operations.py
@@ -1913,7 +1913,7 @@ class MAD(AbstractOperation):
         """Set whether the input to src2 is used when computing."""
         self.set_param("do_add", do_add)
 
-    def swap_io(self) -> None:
+    def swap_io(self, force: bool = False) -> None:
         self._input_ports = [
             self._input_ports[1],
             self._input_ports[0],
@@ -2017,7 +2017,7 @@ class MADS(AbstractOperation):
             or self.input(2).connected_source.operation.is_constant
         )
 
-    def swap_io(self) -> None:
+    def swap_io(self, force: bool = False) -> None:
         self._input_ports = [
             self._input_ports[0],
             self._input_ports[2],

--- a/lib/b_asic/operation.py
+++ b/lib/b_asic/operation.py
@@ -432,9 +432,14 @@ class Operation(GraphComponent, SignalSourceProvider):
         raise NotImplementedError
 
     @abstractmethod
-    def swap_io(self) -> None:
+    def swap_io(self, force: bool = False) -> None:
         """
         Swap inputs (and outputs) of operation.
+
+        Parameters
+        ----------
+        force : bool, optional
+            If True, force the swapping even if :meth:`is_swappable` is False.
 
         Errors if :meth:`is_swappable` is False.
         """
@@ -1108,9 +1113,9 @@ class AbstractOperation(Operation, AbstractGraphComponent):
         # doc-string inherited
         return False
 
-    def swap_io(self) -> None:
+    def swap_io(self, force: bool = False) -> None:
         # doc-string inherited
-        if not self.is_swappable:
+        if not force and not self.is_swappable:
             raise TypeError(f"operation io cannot be swapped for {type(self)}")
         if self.input_count == 2 and self.output_count == 1:
             self._input_ports.reverse()

--- a/lib/b_asic/wdf_operations.py
+++ b/lib/b_asic/wdf_operations.py
@@ -87,7 +87,7 @@ class SymmetricTwoportAdaptor(AbstractOperation):
         else:
             raise ValueError("value must be between -1 and 1 (inclusive)")
 
-    def swap_io(self) -> None:
+    def swap_io(self, force: bool = False) -> None:
         # Swap inputs and outputs and change sign of coefficient
         self._input_ports.reverse()
         for i, ip in enumerate(self._input_ports):
@@ -163,7 +163,7 @@ class SeriesTwoportAdaptor(AbstractOperation):
         else:
             raise ValueError("value must be between 0 and 2 (inclusive)")
 
-    def swap_io(self) -> None:
+    def swap_io(self, force: bool = False) -> None:
         # Swap inputs and outputs and, hence, which port is dependent
         self._input_ports.reverse()
         for i, ip in enumerate(self._input_ports):
@@ -240,7 +240,7 @@ class ParallelTwoportAdaptor(AbstractOperation):
         else:
             raise ValueError("value must be between 0 and 2 (inclusive)")
 
-    def swap_io(self) -> None:
+    def swap_io(self, force: bool = False) -> None:
         # Swap inputs and outputs and, hence, which port is dependent
         self._input_ports.reverse()
         for i, ip in enumerate(self._input_ports):


### PR DESCRIPTION
Typically swap-io should not affect the transfer function of the algorithm.
However, in some cases it can be hard to modify an algorithm without making intermediate steps by swapping-io.

This PR adds a flag (default False) for forcing a swap.