### PR TITLE
Add VHDL codegen for floating-point ReciprocalSquareRoot

### DIFF
--- a/lib/b_asic/code_printer/vhdl/vhdl_printer.py
+++ b/lib/b_asic/code_printer/vhdl/vhdl_printer.py
@@ -1067,6 +1067,28 @@ class VhdlPrinter(Printer):
             "u_fp_rec", component_name="fp_rec", two_inputs=False
         )
 
+    def print_ReciprocalSquareRoot_floating_point_real(
+        self, pe: "ProcessingElement"
+    ) -> tuple[WLS, CODE]:
+        if self._fp_backend != "amd":
+            return self.print_default()
+        # Real-valued operation using AMD Floating-point IP
+        return self._amd_fp_backend(
+            "u_fp_recsqrt", component_name="fp_recsqrt", two_inputs=False
+        )
+
+    def print_ReciprocalSquareRoot_floating_point_complex(
+        self, pe: "ProcessingElement"
+    ) -> tuple[WLS, CODE]:
+        if self._fp_backend != "amd":
+            return self.print_default()
+        if not pe._process_collection.collection[0].real_valued:
+            return self.print_default()
+        # Real-valued operation using AMD Floating-point IP
+        return self._amd_fp_backend(
+            "u_fp_recsqrt", component_name="fp_recsqrt", two_inputs=False
+        )
+
     def print_Negation_floating_point_real(
         self, pe: "ProcessingElement"
     ) -> tuple[WLS, CODE]:


### PR DESCRIPTION
* Add VHDL codegen for floating-point ReciprocalSquareRoot using AMD Floating-Point IP.