### PR TITLE
Fix graph-id generator pickling bug for SFG

### DIFF
--- a/lib/b_asic/scheduler_gui/main_window.py
+++ b/lib/b_asic/scheduler_gui/main_window.py
@@ -505,7 +505,6 @@ class ScheduleMainWindow(QMainWindow, Ui_MainWindow):
         if self._file_name is None:
             self.save_as()
             return
-        self._schedule._sfg._graph_id_generator = None
         with Path(self._file_name).open("wb") as f:
             pickle.dump(self._schedule, f)
         self._add_recent_file(self._file_name)
@@ -529,7 +528,6 @@ class ScheduleMainWindow(QMainWindow, Ui_MainWindow):
         if not filename.endswith(".bsc"):
             filename += ".bsc"
         self._file_name = filename
-        self._schedule._sfg._graph_id_generator = None
         with Path(self._file_name).open("wb") as f:
             pickle.dump(self._schedule, f)
         self._add_recent_file(self._file_name)

--- a/lib/b_asic/sfg.py
+++ b/lib/b_asic/sfg.py
@@ -61,6 +61,16 @@ class GraphIDGenerator:
         """Construct a GraphIDGenerator."""
         self._next_id_number = defaultdict(lambda: id_number_offset)
 
+    def __getstate__(self) -> dict:
+        return {
+            "id_number_offset": self.id_number_offset,
+            "next_id_numbers": dict(self._next_id_number),
+        }
+
+    def __setstate__(self, state: dict) -> None:
+        offset = state["id_number_offset"]
+        self._next_id_number = defaultdict(lambda: offset, state["next_id_numbers"])
+
     def next_id(self, type_name: TypeName, used_ids: MutableSet = set()) -> GraphID:  # noqa: B006
         """Get the next graph id for a certain graph id type."""
         new_id = type_name + str(self._next_id_number[type_name])
@@ -542,6 +552,8 @@ class SFG(AbstractOperation):
         """
         Get the graph id number offset of the graph id generator for this SFG.
         """
+        if self._graph_id_generator is None:
+            self._graph_id_generator = GraphIDGenerator(GraphIDNumber(0))
         return self._graph_id_generator.id_number_offset
 
     @property

--- a/test/unit/test_schedule.py
+++ b/test/unit/test_schedule.py
@@ -2,6 +2,8 @@
 B-ASIC test suite for the schedule module and Schedule class.
 """
 
+import io
+import pickle
 import re
 
 import matplotlib.testing.decorators
@@ -1106,3 +1108,20 @@ class TestGetIoLatency:
         schedule = Schedule(precedence_sfg_delays, scheduler=ASAPScheduler())
 
         assert schedule.get_io_latency() == {"in0": {"out0": 21}}
+
+
+class TestPickle:
+    def test_sfg_accessible_after_pickle(self, sfg_simple_filter):
+        sfg_simple_filter.set_latency_of_type_name(Addition.type_name(), 5)
+        sfg_simple_filter.set_latency_of_type_name(
+            ConstantMultiplication.type_name(), 4
+        )
+        schedule = Schedule(sfg_simple_filter, scheduler=ASAPScheduler())
+        original_op_ids = {op.graph_id for op in schedule.sfg.operations}
+
+        buf = io.BytesIO()
+        pickle.dump(schedule, buf)
+        buf.seek(0)
+        loaded = pickle.load(buf)
+
+        assert {op.graph_id for op in loaded.sfg.operations} == original_op_ids


### PR DESCRIPTION
* Fix graph-id generator pickling bug for SFG (leading to failing methods after loading saved SFGs and schedules)