### PR TITLE
Various fixes and added flags for pipelining control in register-based memories

### DIFF
--- a/lib/b_asic/code_printer/vhdl/register_storage.py
+++ b/lib/b_asic/code_printer/vhdl/register_storage.py
@@ -49,7 +49,8 @@ def architecture(
     sync_rst: bool = False,
     async_rst: bool = False,
     std_logic_vector: bool = True,
-    pipeline_control_signals: bool = False,
+    pipeline_output_mux: bool = False,
+    pipeline_back_edge_mux: bool = False,
 ) -> None:
     """
     Generate architecture for register-based storage.
@@ -70,8 +71,12 @@ def architecture(
         Enable asynchronous reset.
     std_logic_vector : bool, default: True
         If True, use std_logic_vector for data signals. If False, use dt.type_str.
-    pipeline_control_signals : bool, default: False
-        If True, register the control signals.
+    pipeline_output_mux : bool, default: False
+        If True, register the output multiplexer select signal, decoding it one
+        clock cycle earlier to compensate for the added register stage.
+    pipeline_back_edge_mux : bool, default: False
+        If True, register the back-edge multiplexer select signal, decoding it
+        one clock cycle earlier to compensate for the added register stage.
     """
     schedule_time = len(forward_backward_table)
 
@@ -161,7 +166,7 @@ def architecture(
 
     # Shift register back-edge decoding
     common.write(f, 1, "-- Shift register back-edge decoding", start="\n")
-    if pipeline_control_signals:
+    if pipeline_back_edge_mux:
         common.synchronous_process_prologue(
             f, clk="clk", name="shift_reg_back_edge_decode_proc"
         )
@@ -255,16 +260,43 @@ def architecture(
 
     # Output multiplexer decoding logic
     common.write(f, 1, "-- Output multiplexer decoding logic", start="\n")
-    decode_entries = [
-        (i % schedule_time, output_mux_table[entry.outputs_from])
-        for i, entry in enumerate(forward_backward_table)
-        if entry.outputs_from is not None
-    ]
-    common.write(f, 1, "with schedule_cnt_int select")
-    common.write(f, 2, "out_mux_sel <=")
-    for time_val, sel in decode_entries:
-        common.write(f, 3, f"{sel} when {time_val},")
-    common.write(f, 3, "0 when others;")
+    if pipeline_output_mux:
+        decode_entries = [
+            ((i - 1) % schedule_time, output_mux_table[entry.outputs_from])
+            for i, entry in enumerate(forward_backward_table)
+            if entry.outputs_from is not None
+        ]
+        common.synchronous_process_prologue(f, clk="clk", name="out_mux_sel_proc")
+        common.write(f, 3, "if en = '1' then")
+        common.write(f, 4, "case schedule_cnt_int is")
+        for time_val, sel in decode_entries:
+            common.write(f, 5, f"when {time_val} =>")
+            common.write(f, 6, f"out_mux_sel <= {sel};")
+        common.write_lines(
+            f,
+            [
+                (5, "when others =>"),
+                (6, "out_mux_sel <= 0;"),
+                (4, "end case;"),
+                (3, "end if;"),
+            ],
+        )
+        common.synchronous_process_epilogue(
+            f,
+            clk="clk",
+            name="out_mux_sel_proc",
+        )
+    else:
+        decode_entries = [
+            (i % schedule_time, output_mux_table[entry.outputs_from])
+            for i, entry in enumerate(forward_backward_table)
+            if entry.outputs_from is not None
+        ]
+        common.write(f, 1, "with schedule_cnt_int select")
+        common.write(f, 2, "out_mux_sel <=")
+        for time_val, sel in decode_entries:
+            common.write(f, 3, f"{sel} when {time_val},")
+        common.write(f, 3, "0 when others;")
 
     # Output multiplexer logic
     common.write(f, 1, "-- Output multiplexer", start="\n")

--- a/lib/b_asic/code_printer/vhdl/top_level.py
+++ b/lib/b_asic/code_printer/vhdl/top_level.py
@@ -137,10 +137,9 @@ def _collect_mux_info(arch: "Architecture") -> tuple[list[tuple], list[tuple]]:
                             process.start_time + input_latency
                         ) % arch.schedule_time not in read_times:
                             continue
-                        if isinstance(var.write_port, MemoryOutputPort):
-                            continue  # Source is another memory variable, handled in mem mux section
-                        var_op_id = var.write_port.operation.graph_id
-                        var_port_index = var.write_port.index
+                        root_port = var.root_write_port
+                        var_op_id = root_port.operation.graph_id
+                        var_port_index = root_port.index
                         if (
                             var_op_id == source_op.graph_id
                             and var_port_index == source_port.index

--- a/lib/b_asic/code_printer/vhdl/top_level.py
+++ b/lib/b_asic/code_printer/vhdl/top_level.py
@@ -15,6 +15,14 @@ if TYPE_CHECKING:
     from b_asic.architecture import Architecture
 
 
+def _unique_sources(assignments: list[tuple[int, str]]) -> list[str]:
+    seen = []
+    for _, signal in assignments:
+        if signal not in seen:
+            seen.append(signal)
+    return seen
+
+
 def entity(
     f: TextIO, arch: "Architecture", dt: _VhdlDataType, enable_pin: bool = True
 ) -> None:
@@ -228,7 +236,7 @@ def _write_mux_control_signal_declarations(
 
     # PE input mux control signals
     for pe, port_number, assignments in pe_mux_info:
-        unique_sources = {signal for _, signal in assignments}
+        unique_sources = _unique_sources(assignments)
         if len(unique_sources) > 1:
             # Calculate number of bits needed for selector
             sel_bits = selector_bits(len(unique_sources))
@@ -246,7 +254,7 @@ def _write_mux_control_signal_declarations(
 
     # Memory input mux control signals
     for mem, assignments in mem_mux_info:
-        unique_sources = {signal for _, signal in assignments}
+        unique_sources = _unique_sources(assignments)
         if len(unique_sources) > 1:
             sel_bits = selector_bits(len(unique_sources))
             # TODO: Handle multi-input memories here
@@ -281,10 +289,10 @@ def _write_mux_control_signals(
 
     # PE input mux control signals
     for pe, port_number, assignments in pe_mux_info:
-        unique_sources = {signal for _, signal in assignments}
+        unique_sources = _unique_sources(assignments)
         if len(unique_sources) > 1:
             # Build source to index mapping
-            source_to_idx = {src: idx for idx, src in enumerate(list(unique_sources))}
+            source_to_idx = {src: idx for idx, src in enumerate(unique_sources)}
 
             common.write(f, 1, "with schedule_cnt select")
             if multiplexer_control_registered:
@@ -334,10 +342,10 @@ def _write_mux_control_signals(
 
     # Memory input mux control signals
     for mem, assignments in mem_mux_info:
-        unique_sources = {signal for _, signal in assignments}
+        unique_sources = _unique_sources(assignments)
         if len(unique_sources) > 1:
             # Build source to index mapping
-            source_to_idx = {src: idx for idx, src in enumerate(list(unique_sources))}
+            source_to_idx = {src: idx for idx, src in enumerate(unique_sources)}
 
             common.write(f, 1, "with schedule_cnt select")
             if multiplexer_control_registered:
@@ -393,7 +401,7 @@ def _write_interconnect(
 
     # Define PE input interconnect
     for pe, port_number, assignments in pe_mux_info:
-        unique_sources = {signal for _, signal in assignments}
+        unique_sources = _unique_sources(assignments)
 
         if len(unique_sources) == 1:
             # Direct assignment
@@ -408,7 +416,7 @@ def _write_interconnect(
             common.write(f, 1, f"with {pe.entity_name}_{port_number}_sel select")
             common.write(f, 2, f"{pe.entity_name}_{port_number}_in <=")
             sel_bits = selector_bits(len(unique_sources))
-            for idx, source_signal in enumerate(list(unique_sources)):
+            for idx, source_signal in enumerate(unique_sources):
                 sel_value = format(idx, f"0{sel_bits}b")
                 common.write(
                     f,
@@ -420,7 +428,7 @@ def _write_interconnect(
     # Define memory input interconnect
     # TODO: Handle multi-input memories here
     for mem, assignments in mem_mux_info:
-        unique_sources = {signal for _, signal in assignments}
+        unique_sources = _unique_sources(assignments)
 
         if len(unique_sources) == 1:
             # Direct assignment
@@ -432,7 +440,7 @@ def _write_interconnect(
             common.write(f, 1, f"with {mem.entity_name}_0_sel select")
             common.write(f, 2, f"{mem.entity_name}_0_in <=")
             sel_bits = selector_bits(len(unique_sources))
-            for idx, source_signal in enumerate(list(unique_sources)):
+            for idx, source_signal in enumerate(unique_sources):
                 sel_value = format(idx, f"0{sel_bits}b")
                 common.write(
                     f,

--- a/lib/b_asic/code_printer/vhdl/vhdl_printer.py
+++ b/lib/b_asic/code_printer/vhdl/vhdl_printer.py
@@ -129,6 +129,10 @@ class VhdlPrinter(Printer):
                 Use an external schedule counter signal.
             **std_logic_vector** : :class:`bool`, default ``False``
                 Use ``std_logic_vector`` data.
+            **pipeline_output_mux** : :class:`bool`, default ``False``
+                Register the output multiplexer select signal.
+            **pipeline_back_edge_mux** : :class:`bool`, default ``False``
+                Register the back-edge multiplexer select signal.
         """
         dir_path = Path(path)
         dir_path.mkdir(parents=True, exist_ok=True)
@@ -277,7 +281,8 @@ class VhdlPrinter(Printer):
                 )
             register_kwargs = {
                 "std_logic_vector": kwargs.get("std_logic_vector", False),
-                "pipeline_control_signals": kwargs.get("pipeline_mem_control", False),
+                "pipeline_output_mux": kwargs.get("pipeline_output_mux", False),
+                "pipeline_back_edge_mux": kwargs.get("pipeline_back_edge_mux", False),
             }
             register_storage.entity(
                 f,

--- a/lib/b_asic/process.py
+++ b/lib/b_asic/process.py
@@ -213,6 +213,22 @@ class MemoryProcess(Process):
     def write_port(self) -> Any:
         raise NotImplementedError("MemoryProcess should be derived from")
 
+    @property
+    def root_write_port(self) -> "OutputPort":
+        """
+        Resolve the originating :class:`~b_asic.port.OutputPort` of a possibly
+        chained memory variable.
+
+        A chained :class:`MemoryVariable` has a :class:`MemoryOutputPort` as its
+        ``write_port``, pointing at the variable in the upstream memory it was
+        split from. This follows that chain back to the :class:`OutputPort` of
+        the operation that actually produced the data.
+        """
+        write_port = self.write_port
+        while isinstance(write_port, MemoryOutputPort):
+            write_port = write_port.source_variable.write_port
+        return write_port
+
     def split_on_length(
         self,
         length: int = 0,

--- a/lib/b_asic/resource_assigner.py
+++ b/lib/b_asic/resource_assigner.py
@@ -187,9 +187,7 @@ def _split_operations_and_variables(
                     f"Operation {process} has execution time greater than the schedule time."
                 )
 
-    if memory_type == "RAM" and any(
-        p.execution_time > mem_vars.schedule_time for p in mem_vars
-    ):
+    if any(p.execution_time > mem_vars.schedule_time for p in mem_vars):
         log.info(
             "Memory variables with execution time exceeding schedule time detected;"
             " splitting into chains automatically"

--- a/lib/b_asic/resource_assigner.py
+++ b/lib/b_asic/resource_assigner.py
@@ -923,10 +923,9 @@ def _get_mem_node(
 def _get_pe_nodes(
     mem_node: Process, pe_nodes: list[Process]
 ) -> list[tuple[Process, int]]:
-    if isinstance(mem_node.write_port, MemoryOutputPort):
-        return []
-    src_op = mem_node.write_port.operation
-    src_port_index = mem_node.write_port.index
+    root_port = mem_node.root_write_port
+    src_op = root_port.operation
+    src_port_index = root_port.index
     return [
         (pe_process, input_port.index)
         for pe_process in pe_nodes


### PR DESCRIPTION
* Split long variables for register-based memory as well (used to be only for RAM-based) in joint resource assignment
* Fix bug for split variables causing incorrect multiplexing
* Remove set in code generation for determinism
* Add code generation flags for pipelining control in register-based memories